### PR TITLE
fix(env vars): Adding and removing unnecessary env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The new v2 logger implementation has seen a simplification from the last rewrite
 
 We have also decided to not use `logspout` as the mechanism to get logs from each container to the `logger` component. Now we will use [fluentd](http://fluentd.org) which is a widely supported logging framework with hundreds of plugins. This will allow the end user to configure multiple destinations such as Elastic Search and other Syslog compatible endpoints like [papertrail](http://papertrailapp.com).
 
-** This image requires that the `daemonsets` api be available on the kubernetes cluster** For more information on running the `daemonsets` api see the [following](https://github.com/kubernetes/kubernetes/blob/master/docs/api.md#enabling-resources-in-the-extensions-group). 
+** This image requires that the `daemonsets` api be available on the kubernetes cluster** For more information on running the `daemonsets` api see the [following](https://github.com/kubernetes/kubernetes/blob/master/docs/api.md#enabling-resources-in-the-extensions-group).
 
 ## Running logger v2
 The following environment variables can be used to configure logger:
@@ -19,6 +19,8 @@ The following environment variables can be used to configure logger:
 * `WEB_ADDR`: The interface to bind the web server to. Default is `0.0.0.0`.
 * `WEB_PORT`: The port that the web server is listening on. Default is `8088`.
 * `STORAGE_ADAPTER`: How to store logs that are sent to the logger interface. Default is `memory`
+* `NUMBER_OF_LINES`: How many lines to store in the ring buffer. Default is `1000`.
+* `LOG_PATH`: The path of where to store files when using the file storage adapter. Default is `/data/logs`.
 * `DRAIN_URL`: Syslog server that the logger component can send data to. No default.
 
 ## Development

--- a/main.go
+++ b/main.go
@@ -16,16 +16,17 @@ var (
 	// favor of just using environment variables.  Fewer avenues of configuring this component means
 	// less confusion.
 	logAddr     = getopt("LOGGER_ADDR", "0.0.0.0")
-	logHost     = getopt("HOST", "127.0.0.1")
 	logPort, _  = strconv.Atoi(getopt("LOGGER_PORT", "514"))
+	logPath     = getopt("LOG_PATH", "/data/logs")
 	webAddr     = getopt("WEB_ADDR", "0.0.0.0")
 	webPort, _  = strconv.Atoi(getopt("WEB_PORT", "8088"))
 	storageType = getopt("STORAGE_ADAPTER", "memory")
+	numLines, _ = strconv.Atoi(getopt("NUMBER_OF_LINES", "1000"))
 	drainURL    = getopt("DRAIN_URL", "")
 )
 
 func main() {
-	syslogishServer, err := syslogish.NewServer(logAddr, logPort, storageType, drainURL)
+	syslogishServer, err := syslogish.NewServer(logAddr, logPort, storageType, numLines, logPath, drainURL)
 	if err != nil {
 		log.Fatal("Error creating syslogish server", err)
 	}

--- a/storage/factory.go
+++ b/storage/factory.go
@@ -1,46 +1,21 @@
 package storage
 
 import (
-	"fmt"
-	"regexp"
-	"strconv"
-
 	"github.com/deis/logger/storage/file"
 	"github.com/deis/logger/storage/ringbuffer"
 )
 
-// Exported so it can be set by an external agent-- namely main.go, which does some flag parsing.
-var LogRoot string
-
-var memoryAdapterRegex *regexp.Regexp
-
-func init() {
-	memoryAdapterRegex = regexp.MustCompile(`^memory(?::(\d+))?$`)
-}
-
 // NewAdapter returns a pointer to an appropriate implementation of the Adapter interface, as
 // determined by the storeageAdapterType string it is passed.
-func NewAdapter(storeageAdapterType string) (Adapter, error) {
-	if storeageAdapterType == "" || storeageAdapterType == "file" {
-		adapter, err := file.NewStorageAdapter(LogRoot)
+func NewAdapter(storeageAdapterType string, numLines int, logPath string) (Adapter, error) {
+	if storeageAdapterType == "file" {
+		adapter, err := file.NewStorageAdapter(logPath)
 		if err != nil {
 			return nil, err
 		}
 		return adapter, nil
 	}
-	match := memoryAdapterRegex.FindStringSubmatch(storeageAdapterType)
-	if match == nil {
-		return nil, fmt.Errorf("Unrecognized storage adapter type: '%s'", storeageAdapterType)
-	}
-	sizeStr := match[1]
-	if sizeStr == "" {
-		sizeStr = "1000"
-	}
-	size, err := strconv.Atoi(sizeStr)
-	if err != nil {
-		return nil, err
-	}
-	adapter, err := ringbuffer.NewStorageAdapter(size)
+	adapter, err := ringbuffer.NewStorageAdapter(numLines)
 	if err != nil {
 		return nil, err
 	}

--- a/syslogish/server.go
+++ b/syslogish/server.go
@@ -38,7 +38,7 @@ type Server struct {
 }
 
 // NewServer returns a pointer to a new Server instance.
-func NewServer(bindHost string, bindPort int, storageType string, drainURL string) (*Server, error) {
+func NewServer(bindHost string, bindPort int, storageType string, numLines int, logPath string, drainURL string) (*Server, error) {
 	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", bindHost, bindPort))
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func NewServer(bindHost string, bindPort int, storageType string, drainURL strin
 		return nil, err
 	}
 
-	newStorageAdapter, err := storage.NewAdapter(storageType)
+	newStorageAdapter, err := storage.NewAdapter(storageType, numLines, logPath)
 	if err != nil {
 		return nil, fmt.Errorf("configurer: Error creating storage adapter: %v", err)
 	}


### PR DESCRIPTION
fixes #6
fixes #4 
Added LOG_PATH - specifies where to store the logs on disk
Removed HOST - was not being used since we do not publish where logger is running
ADDED NUMBER_OF_LINES - this is used to specify how many lines to store in the ring buffer. Default is 1000
