### PR TITLE
fix(server.go): Use labels when determining container name

### DIFF
--- a/storage/ringbuffer/adapter.go
+++ b/storage/ringbuffer/adapter.go
@@ -3,6 +3,7 @@ package ringbuffer
 import (
 	"container/ring"
 	"fmt"
+	"log"
 	"sync"
 )
 
@@ -74,6 +75,7 @@ func (a *adapter) Write(app string, message string) error {
 		defer a.mutex.Unlock()
 		rb, ok = a.ringBuffers[app]
 		if !ok {
+			log.Printf("Creating buffer for app:%v", app)
 			rb = newRingBuffer(a.bufferSize)
 			a.ringBuffers[app] = rb
 		}


### PR DESCRIPTION
The logger component will now inspect the log message for a few key pieces of information. In particular it will determine if there is a labels map with keys for app and heritage. If neither of these keys exist it will not store the message. If they do exist it will only store the message if the heritage value is equal to deis. Lastly, it will use the app label value as the key for the ringbuffer