### PR TITLE
feat(logger): Add healthz endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /image/bin/logger
 /manifests/*.tmp.yaml
+vendor/

--- a/manifests/deis-logger-rc.yaml
+++ b/manifests/deis-logger-rc.yaml
@@ -26,3 +26,15 @@ spec:
         env:
         - name: "DRAIN_URL"
           value: "tcp://logs.papertrailapp.com:57926"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8088
+          initialDelaySeconds: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8088
+          initialDelaySeconds: 1
+          timeoutSeconds: 1

--- a/weblog/router.go
+++ b/weblog/router.go
@@ -1,0 +1,16 @@
+package weblog
+
+import (
+	"github.com/gorilla/mux"
+)
+
+func newRouter(rh *requestHandler) *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc("/healthz", rh.getHealthz).Methods("GET")
+	r.HandleFunc("/healthz/", rh.getHealthz).Methods("GET")
+	r.HandleFunc("/logs/{app}", rh.getLogs).Methods("GET")
+	r.HandleFunc("/logs/{app}/", rh.getLogs).Methods("GET")
+	r.HandleFunc("/logs/{app}", rh.deleteLogs).Methods("DELETE")
+	r.HandleFunc("/logs/{app}/", rh.deleteLogs).Methods("DELETE")
+	return r
+}


### PR DESCRIPTION
fyi, since this adds a new endpoint, it moves us past the point where we _only_ had to handle `GET` and `DELETE` requests for logs, so I added in gorilla/mux to route requests.  It's actually way saner.

Note that supporting a `/healthz` endpoint meant there could never be an _application_ named `healthz`, so I changed up the routes a little-- logs are not found at `/logs/{app}`.  I will submit a complementary PR to deis/workflow. 