### PR TITLE
chore(ci): Remove unused release.sh script

### DIFF
--- a/_scripts/release.sh
+++ b/_scripts/release.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-#
-# Build and push Docker images to Docker Hub and quay.io.
-#
-cd "$(dirname "$0")" || exit 1
-echo "Building docker image and pushing to quay.io!"
-DEIS_REGISTRY=quay.io/ BUILD_TAG=v2-beta make -C .. build docker-push
-echo "Building docker image and pushing to docker hub!"
-BUILD_TAG=v2-beta make -C .. build docker-push


### PR DESCRIPTION
It is the deploy.sh script that gets used.  This extra script is dead weight and just serves to confuse.