### PR TITLE
ref(build/ci): Use containerized tests and build in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
-language: go
-go:
-  - 1.5.1
-env:
-  - GO15VENDOREXPERIMENT=1
+language: generic
 branches:
   only:
     - master
+cache:
+  directories:
+    - vendor
+sudo: required
 services:
   - docker
-sudo: required
-before_install:
-  - go get github.com/golang/lint/golint
+install:
+  - make bootstrap
 script:
   - make test
 deploy:

--- a/glide.lock
+++ b/glide.lock
@@ -1,6 +1,8 @@
-package: github.com/deis/logger
-import:
-- package: github.com/gorilla/mux
-  version: 26a6070f849969ba72b72256e9f14cf519751690
-- package: github.com/gorilla/context
+hash: bfc38dbd1902d5055a117b3b13a176b3c41c2f3cba9791479b164adffd054621
+updated: 2016-02-17T20:39:56.995047849Z
+imports:
+- name: github.com/gorilla/context
   version: 1c83b3eabd45b6d76072b66b746c20815fb2872d
+- name: github.com/gorilla/mux
+  version: 26a6070f849969ba72b72256e9f14cf519751690
+devImports: []


### PR DESCRIPTION
A containerized build was already available but not being utilized in CI.  This makes minor changes to .travis.yml and the Makefile to leverage the containerized build.

Also in here, the go-dev env is upgraded to 0.7.0, the `coverage` target was broken to begin with _and_ was redundant (the unit tests already output coverage numbers for every package), so it was removed rather than containerized.  `glide update` should not run on every build, as that will produce non-deterministic builds.  `glide install` should be used instead as this is 100% based on the `glide.lock` and `.travis.yml` is updated to run this step _before_ build / test _and_ caches the `vendor` dir to keep that operation speedy from one test run to the next.