### PR TITLE
fix(logger): Use only unprivileged ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,8 @@ We have also decided to not use `logspout` as the mechanism to get logs from eac
 ## Running logger v2
 The following environment variables can be used to configure logger:
 
-* `LOGGER_ADDR`: The interface to bind the logging adapter to. Default is `0.0.0.0`.
-* `LOGGER_PORT`: The port that the logger adapter is listening on. Default is `514`.
-* `WEB_ADDR`: The interface to bind the web server to. Default is `0.0.0.0`.
-* `WEB_PORT`: The port that the web server is listening on. Default is `8088`.
 * `STORAGE_ADAPTER`: How to store logs that are sent to the logger interface. Default is `memory`
 * `NUMBER_OF_LINES`: How many lines to store in the ring buffer. Default is `1000`.
-* `LOG_PATH`: The path of where to store files when using the file storage adapter. Default is `/data/logs`.
 * `DRAIN_URL`: Syslog server that the logger component can send data to. No default.
 
 ## Development

--- a/main.go
+++ b/main.go
@@ -15,22 +15,17 @@ var (
 	// TODO: When semver permits us to do so, many of these flags should probably be phased out in
 	// favor of just using environment variables.  Fewer avenues of configuring this component means
 	// less confusion.
-	logAddr     = getopt("LOGGER_ADDR", "0.0.0.0")
-	logPort, _  = strconv.Atoi(getopt("LOGGER_PORT", "514"))
-	logPath     = getopt("LOG_PATH", "/data/logs")
-	webAddr     = getopt("WEB_ADDR", "0.0.0.0")
-	webPort, _  = strconv.Atoi(getopt("WEB_PORT", "8088"))
 	storageType = getopt("STORAGE_ADAPTER", "memory")
 	numLines, _ = strconv.Atoi(getopt("NUMBER_OF_LINES", "1000"))
 	drainURL    = getopt("DRAIN_URL", "")
 )
 
 func main() {
-	syslogishServer, err := syslogish.NewServer(logAddr, logPort, storageType, numLines, logPath, drainURL)
+	syslogishServer, err := syslogish.NewServer(storageType, numLines, drainURL)
 	if err != nil {
 		log.Fatal("Error creating syslogish server", err)
 	}
-	weblogServer, err := weblog.NewServer(webAddr, webPort, syslogishServer)
+	weblogServer, err := weblog.NewServer(syslogishServer)
 	if err != nil {
 		log.Fatal("Error creating weblog server", err)
 	}

--- a/manifests/deis-logger-fluentd-daemon.yaml
+++ b/manifests/deis-logger-fluentd-daemon.yaml
@@ -28,9 +28,9 @@ spec:
           readOnly: true
         env:
         - name: "SYSLOG_HOST"
-          value: $(DEIS_LOGGER_PORT_514_UDP_ADDR)
+          value: $(DEIS_LOGGER_SERVICE_HOST)
         - name: "SYSLOG_PORT"
-          value: $(DEIS_LOGGER_PORT_514_UDP_PORT)
+          value: $(DEIS_LOGGER_SERVICE_PORT_TRANSPORT)
       volumes:
       - name: varlog
         hostPath:

--- a/manifests/deis-logger-rc.yaml
+++ b/manifests/deis-logger-rc.yaml
@@ -20,7 +20,7 @@ spec:
         ports:
         - containerPort: 8088
           name: http
-        - containerPort: 514
+        - containerPort: 1514
           name: transport
           protocol: UDP
         env:

--- a/manifests/deis-logger-svc.yaml
+++ b/manifests/deis-logger-svc.yaml
@@ -12,7 +12,7 @@ spec:
     targetPort: http
   - port: 514
     name: transport
-    targetPort: transport
+    targetPort: 1514
     protocol: UDP
   selector:
     app: deis-logger

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,24 +1,17 @@
 FROM alpine:3.3
 
-# install common packages
-RUN apk add --update-cache \
-	libcap \
-	&& rm -rf /var/cache/apk/*
-
 # add logger user
 RUN addgroup -S logger && \
 	adduser -S -G logger -H -h /opt/logger -D logger
 
 ADD . /
 
-# Fix some permission since we'll be running as a non-root user.  This includes enabling
-# logger to always bind to low/privileged ports, even when running as a non-root user.
-RUN chown -R logger:logger /opt/logger && \
-	setcap 'cap_net_bind_service=+ep' /opt/logger/sbin/logger
+# Fix some permission since we'll be running as a non-root user.
+RUN chown -R logger:logger /opt/logger
 
 USER logger
 
 CMD ["/opt/logger/sbin/logger"]
-EXPOSE 514 8088
+EXPOSE 1514 8088
 
 ENV DEIS_RELEASE v2-beta

--- a/storage/factory.go
+++ b/storage/factory.go
@@ -8,9 +8,9 @@ import (
 
 // NewAdapter returns a pointer to an appropriate implementation of the Adapter interface, as
 // determined by the storeageAdapterType string it is passed.
-func NewAdapter(storeageAdapterType string, numLines int, logPath string) (Adapter, error) {
+func NewAdapter(storeageAdapterType string, numLines int) (Adapter, error) {
 	if storeageAdapterType == "file" {
-		adapter, err := file.NewStorageAdapter(logPath)
+		adapter, err := file.NewStorageAdapter()
 		if err != nil {
 			return nil, err
 		}

--- a/storage/factory_test.go
+++ b/storage/factory_test.go
@@ -2,25 +2,20 @@ package storage
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"testing"
 )
 
 func TestGetUsingInvalidValues(t *testing.T) {
-	logPath, _ := ioutil.TempDir("", "log-tests")
-	defer os.Remove(logPath)
-	_, err := NewAdapter("bogus", 1, logPath)
+	_, err := NewAdapter("bogus", 1)
 	if err == nil || err.Error() != fmt.Sprintf("Unrecognized storage adapter type: '%s'", "bogus") {
 		t.Error("Did not receive expected error message")
 	}
 }
 
 func TestGetFileBasedAdapter(t *testing.T) {
-	logPath, _ := ioutil.TempDir("", "log-tests")
-	defer os.Remove(logPath)
-	a, err := NewAdapter("file", 1, logPath)
+	a, err := NewAdapter("file", 1)
 	if err != nil {
 		t.Error(err)
 	}
@@ -32,9 +27,7 @@ func TestGetFileBasedAdapter(t *testing.T) {
 }
 
 func TestGetMemoryBasedAdapter(t *testing.T) {
-	logPath, _ := ioutil.TempDir("", "log-tests")
-	defer os.Remove(logPath)
-	a, err := NewAdapter("memory", 1, logPath)
+	a, err := NewAdapter("memory", 1)
 	if err != nil {
 		t.Error(err)
 	}

--- a/storage/file/adapter.go
+++ b/storage/file/adapter.go
@@ -10,22 +10,16 @@ import (
 	"sync"
 )
 
+var logRoot = "/data/logs"
+
 type adapter struct {
-	logRoot string
-	files   map[string]*os.File
-	mutex   sync.Mutex
+	files map[string]*os.File
+	mutex sync.Mutex
 }
 
 // NewStorageAdapter returns a pointer to a new instance of a file-based storage.Adapter.
-func NewStorageAdapter(logRoot string) (*adapter, error) {
-	src, err := os.Stat(logRoot)
-	if err != nil {
-		return nil, fmt.Errorf("Directory %s does not exist", logRoot)
-	}
-	if !src.IsDir() {
-		return nil, fmt.Errorf("%s is not a directory", logRoot)
-	}
-	return &adapter{logRoot: logRoot, files: make(map[string]*os.File)}, nil
+func NewStorageAdapter() (*adapter, error) {
+	return &adapter{files: make(map[string]*os.File)}, nil
 }
 
 // Write adds a log message to to an app-specific log file
@@ -125,7 +119,7 @@ func (a *adapter) getFile(app string) (*os.File, error) {
 }
 
 func (a *adapter) getFilePath(app string) string {
-	return path.Join(a.logRoot, app+".log")
+	return path.Join(logRoot, app+".log")
 }
 
 func fileExists(path string) (bool, error) {

--- a/storage/file/adapter_test.go
+++ b/storage/file/adapter_test.go
@@ -11,13 +11,14 @@ import (
 const app string = "test-app"
 
 func TestReadFromNonExistingApp(t *testing.T) {
-	logRoot, err := ioutil.TempDir("", "log-tests")
+	var err error
+	logRoot, err = ioutil.TempDir("", "log-tests")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(logRoot)
 	// Initialize a new storage adapter
-	a, err := NewStorageAdapter(logRoot)
+	a, err := NewStorageAdapter()
 	if err != nil {
 		t.Error(err)
 	}
@@ -31,38 +32,14 @@ func TestReadFromNonExistingApp(t *testing.T) {
 	}
 }
 
-func TestWithBadLogRoot(t *testing.T) {
-	// Initialize with bad log path (doesn't exist)
-	bogusLogRoot := "/bogus/path"
-	a, err := NewStorageAdapter(bogusLogRoot)
-	if a != nil {
-		t.Error("Expected no storage adapter, but got one")
-	}
-	if err == nil || err.Error() != fmt.Sprintf("Directory %s does not exist", bogusLogRoot) {
-		t.Error("Did not receive expected error message")
-	}
-	// Create a temporary file
-	file, err := ioutil.TempFile("", "log-file")
-	if err != nil {
-		t.Error(err)
-	}
-	defer os.Remove(file.Name())
-	a, err = NewStorageAdapter(file.Name())
-	if a != nil {
-		t.Error("Expected no storage adapter, but got one")
-	}
-	if err == nil || err.Error() != fmt.Sprintf("%s is not a directory", file.Name()) {
-		t.Error("Did not receive expected error message")
-	}
-}
-
 func TestLogs(t *testing.T) {
-	logRoot, err := ioutil.TempDir("", "log-tests")
+	var err error
+	logRoot, err = ioutil.TempDir("", "log-tests")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(logRoot)
-	a, err := NewStorageAdapter(logRoot)
+	a, err := NewStorageAdapter()
 	if err != nil {
 		t.Error(err)
 	}
@@ -99,12 +76,13 @@ func TestLogs(t *testing.T) {
 }
 
 func TestDestroy(t *testing.T) {
-	logRoot, err := ioutil.TempDir("", "log-tests")
+	var err error
+	logRoot, err = ioutil.TempDir("", "log-tests")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(logRoot)
-	a, err := NewStorageAdapter(logRoot)
+	a, err := NewStorageAdapter()
 	if err != nil {
 		t.Error(err)
 	}
@@ -132,12 +110,13 @@ func TestDestroy(t *testing.T) {
 }
 
 func TestReopen(t *testing.T) {
-	logRoot, err := ioutil.TempDir("", "log-tests")
+	var err error
+	logRoot, err = ioutil.TempDir("", "log-tests")
 	if err != nil {
 		t.Error(err)
 	}
 	defer os.Remove(logRoot)
-	a, err := NewStorageAdapter(logRoot)
+	a, err := NewStorageAdapter()
 	if err != nil {
 		t.Error(err)
 	}

--- a/syslogish/server.go
+++ b/syslogish/server.go
@@ -14,7 +14,11 @@ import (
 	"github.com/deis/logger/storage"
 )
 
-const queueSize = 500
+const (
+	bindHost  = "0.0.0.0"
+	bindPort  = 1514
+	queueSize = 500
+)
 
 var appRegex *regexp.Regexp
 
@@ -38,7 +42,7 @@ type Server struct {
 }
 
 // NewServer returns a pointer to a new Server instance.
-func NewServer(bindHost string, bindPort int, storageType string, numLines int, logPath string, drainURL string) (*Server, error) {
+func NewServer(storageType string, numLines int, drainURL string) (*Server, error) {
 	addr, err := net.ResolveUDPAddr("udp", fmt.Sprintf("%s:%d", bindHost, bindPort))
 	if err != nil {
 		return nil, err
@@ -48,7 +52,7 @@ func NewServer(bindHost string, bindPort int, storageType string, numLines int, 
 		return nil, err
 	}
 
-	newStorageAdapter, err := storage.NewAdapter(storageType, numLines, logPath)
+	newStorageAdapter, err := storage.NewAdapter(storageType, numLines)
 	if err != nil {
 		return nil, fmt.Errorf("configurer: Error creating storage adapter: %v", err)
 	}

--- a/weblog/server.go
+++ b/weblog/server.go
@@ -9,22 +9,23 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const (
+	bindHost = "0.0.0.0"
+	bindPort = 8088
+)
+
 // Server implements a simple HTTP server that handles GET and DELETE requests for application
 // logs.  These actions are accomplished by delegating to a syslogish.Server, which will broker
 // communication between its underlying storage.Adapter and this weblog server.
 type Server struct {
 	listening bool
-	bindHost  string
-	bindPort  int
 	router    *mux.Router
 }
 
 // NewServer returns a pointer to a new Server instance.
-func NewServer(bindHost string, bindPort int, syslogishServer *syslogish.Server) (*Server, error) {
+func NewServer(syslogishServer *syslogish.Server) (*Server, error) {
 	return &Server{
-		bindHost: bindHost,
-		bindPort: bindPort,
-		router:   newRouter(newRequestHandler(syslogishServer)),
+		router: newRouter(newRequestHandler(syslogishServer)),
 	}, nil
 }
 
@@ -34,13 +35,13 @@ func (s *Server) Listen() {
 	if !s.listening {
 		s.listening = true
 		go s.listen()
-		log.Printf("weblog server running on %s:%v", s.bindHost, s.bindPort)
+		log.Printf("weblog server running on %s:%d", bindHost, bindPort)
 	}
 }
 
 func (s *Server) listen() {
 	http.Handle("/", s.router)
-	if err := http.ListenAndServe(fmt.Sprintf("%s:%d", s.bindHost, s.bindPort), nil); err != nil {
+	if err := http.ListenAndServe(fmt.Sprintf("%s:%d", bindHost, bindPort), nil); err != nil {
 		log.Fatal("weblog server stopped", err)
 	}
 }


### PR DESCRIPTION
This PR does two related things.  The primary goal was to ensure logger only binds to unprivileged ports since it now runs as a non-root user.  To ensure that the ability to _select_ what ports logger listens on is going away.  This ability actually matters very little anyhow since it should matter to _anyone_ what ports a process listens to _within_ a container.  In k8s, if you really care about what port you _connect_ to something on, then that something's _service_ is the right level of abstraction where you can modify that.

In keeping with this notion, several other configuration options that simply aren't needed have been removed.

If drain related configuration options appear not to have been touched, that is because PR #35 removes the drain capability (which is no longer needed).  This PR will require rebasing if #35 is merged first-- or vice versa.

cc @jchauncey 