### PR TITLE
chore(Makefile): update go-dev image to 0.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ REPO_PATH = github.com/deis/logger
 
 # The following variables describe the containerized development environment
 # and other build options
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.7.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.11.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 DEV_ENV_CMD_INT := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}


### PR DESCRIPTION
See https://github.com/deis/docker-go-dev/releases/tag/0.11.0

Closes #56.