### PR TITLE
fix(server): Fix regex to help remove duplicate lines

### DIFF
--- a/syslogish/server.go
+++ b/syslogish/server.go
@@ -16,7 +16,7 @@ const (
 	bindHost          = "0.0.0.0"
 	bindPort          = 1514
 	queueSize         = 500
-	controllerPattern = `^(INFO|WARN|DEBUG|ERROR)\s+(\[(\S+)\])+:(.*)`
+	controllerPattern = `(INFO|WARN|DEBUG|ERROR)\s+(\[(\S+)\])+:(.*)`
 )
 
 var appRegex *regexp.Regexp


### PR DESCRIPTION
The controller regex was allowing duplicate log lines.

Testing Steps:
1) Build and deploy new logger
2) Bounce all fluentd pods (this might not be needed but its habit for me)
3) Create an application
4) `deis logs` and make sure there are not duplicate lines from the controller

It is possible that there are duplicate lines from fluentd (I am investigating that now) but the controller log lines shouldnt be duplicated.