### PR TITLE
fix(weblog): strip newline characters from log line

### DIFF
--- a/weblog/requesthandler.go
+++ b/weblog/requesthandler.go
@@ -50,7 +50,8 @@ func (h requestHandler) getLogs(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Printf("Returning the last %v lines for %s", logLines, app)
 	for _, line := range logs {
-		fmt.Fprintf(w, "%s\n", line)
+		// strip any trailing newline characters from the logs
+		fmt.Fprintf(w, "%s\n", strings.TrimSuffix(line, "\n"))
 	}
 }
 


### PR DESCRIPTION
log lines retrieved from fluentd contain newline characters. This prevents log lines being sent to the controller with two newline characters.

confirmed that the logger is to blame with the following:

```
><> kd exec -it deis-controller-acyqg python manage.py shell
>>> from api.models import App
>>> a = App.objects.all()[0]
>>> a
<App: foo>
>>> a.logs()
"b'INFO [foo]: bacongobbler created initial release\\n\\nINFO [foo]: bacongobbler created initial release\\n\\nINFO [foo]: domain foo added\\n\\nINFO [foo]: domain foo added\\n\\nINFO [foo]: bacongobbler created initial release\\n\\nINFO [foo]: bacongobbler created initial release\\n\\nINFO [foo]: domain foo added\\n\\nINFO [foo]: domain foo added\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nfoo-v3-cmd-n8tb3 -- 2016/05/13 20:12:37 server is listening on 8080...\\n\\nfoo-v3-cmd-n8tb3 -- 2016/05/13 20:12:37 server is listening on 8080...\\n\\nfoo-v3-cmd-n8tb3 -- 2016/05/13 20:12:37 server is listening on 8080...\\n\\nfoo-v3-cmd-n8tb3 -- 2016/05/13 20:12:37 server is listening on 8080...\\n\\nfoo-v2-cmd-fr8jf -- 2016/05/13 20:12:22 server is listening on 8080...\\n\\nfoo-v2-cmd-fr8jf -- 2016/05/13 20:12:22 server is listening on 8080...\\n\\nfoo-v2-cmd-fr8jf -- 2016/05/13 20:12:32 10.244.0.17:57708 GET /\\n\\nfoo-v2-cmd-fr8jf -- 2016/05/13 20:12:32 10.244.0.17:57708 GET /\\n\\nfoo-v2-cmd-fr8jf -- 2016/05/13 20:12:22 server is listening on 8080...\\n\\nfoo-v2-cmd-fr8jf -- 2016/05/13 20:12:22 server is listening on 8080...\\n\\nfoo-v2-cmd-fr8jf -- 2016/05/13 20:12:32 10.244.0.17:57708 GET /\\n\\nfoo-v2-cmd-fr8jf -- 2016/05/13 20:12:32 10.244.0.17:57708 GET /\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nfoo-v6-cmd-l4d5f -- 2016/05/13 20:13:22 server is listening on 8080...\\n\\nfoo-v6-cmd-l4d5f -- 2016/05/13 20:13:22 server is listening on 8080...\\n\\nfoo-v6-cmd-l4d5f -- 2016/05/13 20:13:22 server is listening on 8080...\\n\\nfoo-v6-cmd-l4d5f -- 2016/05/13 20:13:22 server is listening on 8080...\\n\\nfoo-v7-cmd-xf3pw -- 2016/05/13 20:13:36 server is listening on 8080...\\n\\nfoo-v7-cmd-xf3pw -- 2016/05/13 20:13:36 server is listening on 8080...\\n\\nfoo-v7-cmd-xf3pw -- 2016/05/13 20:13:36 server is listening on 8080...\\n\\nfoo-v7-cmd-xf3pw -- 2016/05/13 20:13:36 server is listening on 8080...\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nINFO [foo]: bacongobbler deployed deis/example-go\\n\\nfoo-v11-cmd-lhvfi -- 2016/05/13 20:14:36 server is listening on 8080...\\n\\nfoo-v11-cmd-lhvfi -- 2016/05/13 20:14:36 server is listening on 8080...\\n\\nfoo-v11-cmd-lhvfi -- 2016/05/13 20:14:36 server is listening on 8080...\\n\\nfoo-v11-cmd-lhvfi -- 2016/05/13 20:14:36 server is listening on 8080...\\n\\nfoo-v10-cmd-j4vlz -- 2016/05/13 20:14:22 server is listening on 8080...\\n\\nfoo-v10-cmd-j4vlz -- 2016/05/13 20:14:22 server is listening on 8080...\\n\\nfoo-v10-cmd-j4vlz -- 2016/05/13 20:14:22 server is listening on 8080...\\n\\nfoo-v10-cmd-j4vlz -- 2016/05/13 20:14:22 server is listening on 8080...\\n\\n'"
```

The important part is here, where we confirm that the double newline characters are coming from the logger:

```
>>> from django.conf import settings
>>> import requests
>>> r = requests.get('http://{}:{}/logs/{}?log_lines={}'.format(settings.LOGGER_HOST, settings.LOGGER_PORT, a.id, 1))               
>>> r.content
b'foo-v10-cmd-j4vlz -- 2016/05/13 20:14:22 server is listening on 8080...\n\n'
>>> r = requests.get('http://{}:{}/logs/{}?log_lines={}'.format(settings.LOGGER_HOST, settings.LOGGER_PORT, a.id, 2))        
>>> r.content
b'foo-v10-cmd-j4vlz -- 2016/05/13 20:14:22 server is listening on 8080...\n\nfoo-v10-cmd-j4vlz -- 2016/05/13 20:14:22 server is listening on 8080...\n\n'
```

addresses deis/workflow#202