### PR TITLE
docs(README): add codecov.io badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /rootfs/opt/logger/sbin/logger
 /manifests/*.tmp.yaml
 vendor/
+coverage.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,6 @@ services:
 install:
   - make bootstrap
 script:
-  - make build test
+  - make build test-cover
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ REPO_PATH = github.com/deis/logger
 
 # The following variables describe the containerized development environment
 # and other build options
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.11.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.13.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_CMD := docker run --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
 DEV_ENV_CMD_INT := docker run -it --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR} ${DEV_ENV_IMAGE}
@@ -75,6 +75,9 @@ update-manifests:
 	sed 's#\(image:\) .*#\1 $(IMAGE)#' manifests/deis-logger-rc.yaml > manifests/deis-logger-rc.tmp.yaml
 
 test: test-style test-unit
+
+test-cover:
+	${DEV_ENV_CMD} test-cover.sh
 
 test-style: check-docker
 	${DEV_ENV_CMD} make style-check

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Deis Logger
 [![Build Status](https://travis-ci.org/deis/logger.svg?branch=master)](https://travis-ci.org/deis/logger)
+[![codecov.io](https://codecov.io/github/deis/logger/coverage.svg?branch=master)](https://codecov.io/github/deis/logger?branch=master)
 [![Go Report Card](http://goreportcard.com/badge/deis/logger)](http://goreportcard.com/report/deis/logger)
 [![Docker Repository on Quay](https://quay.io/repository/deis/logger/status "Docker Repository on Quay")](https://quay.io/repository/deis/logger)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  branch: master
+  slug: "deis/logger"


### PR DESCRIPTION
# Summary of Changes

`make test-cover` runs the go unit tests while accumulating a `coverage.txt` file suitable for shipping to https://codecov.io/. This also adds a badge to README.md: [![codecov.io](https://codecov.io/github/deis/logger/coverage.svg?branch=master)](https://codecov.io/github/deis/logger?branch=master)