### PR TITLE
ref(storage,syslogish): make all storage adapter initialization func return the storage.Adapter interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /manifests/*.tmp.yaml
 vendor/
 coverage.txt
+logger

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ SHELL = /bin/bash
 GO = go
 GOFMT = gofmt -l
 GOLINT = golint
+GOLINT_PACKAGES = ./log ./storage ./tests ./weblog ./
 GOTEST = $(GO) test --cover --race -v
 GOVET = $(GO) vet
 GO_FILES = $(wildcard *.go)
@@ -96,7 +97,7 @@ style-check:
 	$(GOFMT) $(GO_PACKAGES) $(GO_FILES)
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
 	$(GOVET) $(REPO_PATH) $(GO_PACKAGES_REPO_PATH)
-	$(GOLINT) ./...
+	$(GOLINT) $(GOLINT_PACKAGES)
 	shellcheck $(SHELL_SCRIPTS)
 
 start-test-redis:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ SHELL = /bin/bash
 GO = go
 GOFMT = gofmt -l
 GOLINT = golint
-GOLINT_PACKAGES = ./log ./storage ./tests ./weblog ./
 GOTEST = $(GO) test --cover --race -v
 GOVET = $(GO) vet
 GO_FILES = $(wildcard *.go)
@@ -97,7 +96,11 @@ style-check:
 	$(GOFMT) $(GO_PACKAGES) $(GO_FILES)
 	@$(GOFMT) $(GO_PACKAGES) $(GO_FILES) | read; if [ $$? == 0 ]; then echo "gofmt check failed."; exit 1; fi
 	$(GOVET) $(REPO_PATH) $(GO_PACKAGES_REPO_PATH)
-	$(GOLINT) $(GOLINT_PACKAGES)
+	$(GOLINT) ./log
+	$(GOLINT) ./storage
+	$(GOLINT) ./tests
+	$(GOLINT) ./weblog
+	$(GOLINT) .
 	shellcheck $(SHELL_SCRIPTS)
 
 start-test-redis:

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test-unit: start-test-redis
 		--link ${REDIS_CONTAINER_NAME}:TEST_REDIS \
 		${DEV_ENV_IMAGE} bash -c 'DEIS_LOGGER_REDIS_SERVICE_HOST=$$TEST_REDIS_PORT_6379_TCP_ADDR \
 		DEIS_LOGGER_REDIS_SERVICE_PORT=$$TEST_REDIS_PORT_6379_TCP_PORT \
-		$(GOTEST) $$(glide nv)' \
+		$(GOTEST) -tags="testredis" $$(glide nv)' \
 		|| (make stop-test-redis && false)
 	make stop-test-redis
 

--- a/log/model.go
+++ b/log/model.go
@@ -17,7 +17,7 @@ type Message struct {
 	Docker     Docker     `json:"docker"`
 }
 
-// Kuberentes specific log message fields
+// Kubernetes specific log message fields
 type Kubernetes struct {
 	Namespace     string            `json:"namespace_name"`
 	PodID         string            `json:"pod_id"`

--- a/storage/factory.go
+++ b/storage/factory.go
@@ -2,34 +2,39 @@ package storage
 
 import (
 	"fmt"
-	"github.com/deis/logger/storage/file"
-	"github.com/deis/logger/storage/redis"
-	"github.com/deis/logger/storage/ringbuffer"
 )
 
+type errUnrecognizedStorageAdapterType struct {
+	adapterType string
+}
+
+func (e errUnrecognizedStorageAdapterType) Error() string {
+	return fmt.Sprintf("Unrecognized storage adapter type: %s", e.adapterType)
+}
+
 // NewAdapter returns a pointer to an appropriate implementation of the Adapter interface, as
-// determined by the storeageAdapterType string it is passed.
-func NewAdapter(storeageAdapterType string, numLines int) (Adapter, error) {
-	if storeageAdapterType == "file" {
-		adapter, err := file.NewStorageAdapter()
+// determined by the adapterType string it is passed.
+func NewAdapter(adapterType string, numLines int) (Adapter, error) {
+	if adapterType == "file" {
+		adapter, err := NewFileAdapter()
 		if err != nil {
 			return nil, err
 		}
 		return adapter, nil
 	}
-	if storeageAdapterType == "memory" {
-		adapter, err := ringbuffer.NewStorageAdapter(numLines)
+	if adapterType == "memory" {
+		adapter, err := NewRingBufferAdapter(numLines)
 		if err != nil {
 			return nil, err
 		}
 		return adapter, nil
 	}
-	if storeageAdapterType == "redis" {
-		adapter, err := redis.NewStorageAdapter(numLines)
+	if adapterType == "redis" {
+		adapter, err := NewRedisStorageAdapter(numLines)
 		if err != nil {
 			return nil, err
 		}
 		return adapter, nil
 	}
-	return nil, fmt.Errorf("Unrecognized storage adapter type: '%s'", storeageAdapterType)
+	return nil, errUnrecognizedStorageAdapterType{adapterType: adapterType}
 }

--- a/storage/redis_adapter_test.go
+++ b/storage/redis_adapter_test.go
@@ -1,44 +1,42 @@
-package ringbuffer
+package storage
 
 import (
 	"fmt"
 	"testing"
 )
 
-const app string = "test-app"
-
-func TestReadFromNonExistingApp(t *testing.T) {
+func TestRedisReadFromNonExistingApp(t *testing.T) {
 	// Initialize a new storage adapter
-	a, err := NewStorageAdapter(10)
+	a, err := NewRedisStorageAdapter(10)
 	if err != nil {
 		t.Error(err)
 	}
-	// No logs have been writter; there should be no ringBuffer for app
+	// No logs have been written; there should be no redis list for app
 	messages, err := a.Read(app, 10)
 	if messages != nil {
 		t.Error("Expected no messages, but got some")
 	}
-	if err == nil || err.Error() != fmt.Sprintf("Could not find logs for '%s'. No ringbuffer existed for '%s'.", app, app) {
+	if err == nil || err.Error() != fmt.Sprintf("Could not find logs for '%s'", app) {
 		t.Error("Did not receive expected error message")
 	}
 }
 
-func TestWithBadBufferSizes(t *testing.T) {
+func TestRedisWithBadBufferSizes(t *testing.T) {
 	// Initialize with invalid buffer sizes
 	for _, size := range []int{-1, 0} {
-		a, err := NewStorageAdapter(size)
+		a, err := NewRedisStorageAdapter(size)
 		if a != nil {
 			t.Error("Expected no storage adapter, but got one")
 		}
-		if err == nil || err.Error() != fmt.Sprintf("Invalid ringBuffer size: %d", size) {
+		if err == nil || err.Error() != fmt.Sprintf("Invalid buffer size: %d", size) {
 			t.Error("Did not receive expected error message")
 		}
 	}
 }
 
-func TestLogs(t *testing.T) {
+func TestRedisLogs(t *testing.T) {
 	// Initialize with small buffers
-	a, err := NewStorageAdapter(10)
+	a, err := NewRedisStorageAdapter(10)
 	if err != nil {
 		t.Error(err)
 	}
@@ -96,8 +94,8 @@ func TestLogs(t *testing.T) {
 	}
 }
 
-func TestDestroy(t *testing.T) {
-	a, err := NewStorageAdapter(10)
+func TestRedisDestroy(t *testing.T) {
+	a, err := NewRedisStorageAdapter(10)
 	if err != nil {
 		t.Error(err)
 	}
@@ -105,16 +103,24 @@ func TestDestroy(t *testing.T) {
 	if err := a.Write(app, "Hello, log!"); err != nil {
 		t.Error(err)
 	}
-	// A ringBuffer should exist for the app
-	if _, ok := a.ringBuffers[app]; !ok {
-		t.Error("Log ringbuffer was expected to exist, but doesn't.")
+	// A redis list should exist for the app
+	exists, err := a.redisClient.Exists(app).Result()
+	if err != nil {
+		t.Error(err)
+	}
+	if !exists {
+		t.Error("Log redis list was expected to exist, but doesn't.")
 	}
 	// Now destroy it
 	if err := a.Destroy(app); err != nil {
 		t.Error(err)
 	}
-	// Now check that the ringBuffer no longer exists
-	if _, ok := a.ringBuffers[app]; ok {
-		t.Error("Log ringbuffer still exist, but was expected not to.")
+	// Now check that the redis list no longer exists
+	exists, err = a.redisClient.Exists(app).Result()
+	if err != nil {
+		t.Error(err)
+	}
+	if exists {
+		t.Error("Log redis list still exist, but was expected not to.")
 	}
 }

--- a/storage/redis_adapter_test.go
+++ b/storage/redis_adapter_test.go
@@ -1,3 +1,5 @@
+// +build testredis
+
 package storage
 
 import (

--- a/storage/redis_config.go
+++ b/storage/redis_config.go
@@ -1,4 +1,4 @@
-package redis
+package storage
 
 import (
 	"github.com/kelseyhightower/envconfig"
@@ -8,15 +8,15 @@ const (
 	appName = "logger"
 )
 
-type config struct {
+type redisConfig struct {
 	RedisHost     string `envconfig:"DEIS_LOGGER_REDIS_SERVICE_HOST" default:""`
 	RedisPort     int    `envconfig:"DEIS_LOGGER_REDIS_SERVICE_PORT" default:"6379"`
 	RedisPassword string `envconfig:"DEIS_LOGGER_REDIS_PASSWORD" default:""`
 	RedisDB       int    `envconfig:"DEIS_LOGGER_REDIS_DB" default:"0"`
 }
 
-func parseConfig(appName string) (*config, error) {
-	ret := new(config)
+func parseConfig(appName string) (*redisConfig, error) {
+	ret := new(redisConfig)
 	if err := envconfig.Process(appName, ret); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes https://github.com/deis/logger/issues/89

Big changes in this patch:

- Moves the storage adapter factory into a `factory` subpackage of `github.com/deis/logger/storage`
  - Eliminates a circular dependency from the storage adapter packages and `storage`
- Adds a `testredis` build tag to the `./storage/redis_adapter_test.go` (which was added in https://github.com/deis/logger/pull/88), so that a developer can still run `go test $(glide nv)` without requiring a redis server be up and running. `make test`, however, still runs tests with that tag enabled, because it also runs a redis server in a linked container