### PR TITLE
feat(ringbuffer): Treat empty ringbuffer as error

### DIFF
--- a/storage/ringbuffer/adapter.go
+++ b/storage/ringbuffer/adapter.go
@@ -88,9 +88,13 @@ func (a *adapter) Write(app string, message string) error {
 func (a *adapter) Read(app string, lines int) ([]string, error) {
 	rb, ok := a.ringBuffers[app]
 	if ok {
-		return rb.read(lines), nil
+		data := rb.read(lines)
+		if len(data) == 0 {
+			return nil, fmt.Errorf("Could not find logs for '%s'. Ringbuffer existed for '%s', but returned no logs.", app, app)
+		}
+		return data, nil
 	}
-	return nil, fmt.Errorf("Could not find logs for '%s'", app)
+	return nil, fmt.Errorf("Could not find logs for '%s'. No ringbuffer existed for '%s'.", app, app)
 }
 
 // Destroy deletes stored logs for the specified application

--- a/storage/ringbuffer/adapter_test.go
+++ b/storage/ringbuffer/adapter_test.go
@@ -18,7 +18,7 @@ func TestReadFromNonExistingApp(t *testing.T) {
 	if messages != nil {
 		t.Error("Expected no messages, but got some")
 	}
-	if err == nil || err.Error() != fmt.Sprintf("Could not find logs for '%s'", app) {
+	if err == nil || err.Error() != fmt.Sprintf("Could not find logs for '%s'. No ringbuffer existed for '%s'.", app, app) {
 		t.Error("Did not receive expected error message")
 	}
 }


### PR DESCRIPTION
cc @arschles @jchauncey 

This is a first step toward isolating the as-yet-unexplained scenario we have encountered in load testing where two back-to-back executions of `deis logs` first return some logs, and then none.