### PR TITLE
Optimize redis storage adapter and make default

### DIFF
--- a/config.go
+++ b/config.go
@@ -9,7 +9,7 @@ const (
 )
 
 type config struct {
-	StorageType    string `envconfig:"STORAGE_ADAPTER" default:"memory"`
+	StorageType    string `envconfig:"STORAGE_ADAPTER" default:"redis"`
 	NumLines       int    `envconfig:"NUMBER_OF_LINES" default:"1000"`
 	AggregatorType string `envconfig:"AGGREGATOR_TYPE" default:"nsq"`
 }

--- a/log/aggregator_factory_test.go
+++ b/log/aggregator_factory_test.go
@@ -9,6 +9,9 @@ import (
 type stubStorageAdapter struct {
 }
 
+func (a *stubStorageAdapter) Start() {
+}
+
 func (a *stubStorageAdapter) Write(app string, message string) error {
 	return nil
 }
@@ -23,6 +26,9 @@ func (a *stubStorageAdapter) Destroy(app string) error {
 
 func (a *stubStorageAdapter) Reopen() error {
 	return nil
+}
+
+func (a *stubStorageAdapter) Stop() {
 }
 
 func TestGetUsingInvalidValues(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ func main() {
 	if err != nil {
 		l.Fatal("Error creating storage adapter: ", err)
 	}
+	storageAdapter.Start()
+	defer storageAdapter.Stop()
 
 	aggregator, err := log.NewAggregator(cfg.AggregatorType, storageAdapter)
 	if err != nil {

--- a/manifests/deis-logger-rc.yaml
+++ b/manifests/deis-logger-rc.yaml
@@ -19,8 +19,13 @@ spec:
         image: quay.io/deis/logger:v2-beta
         imagePullPolicy: Always
         env:
-        - name: NSQ_HANDLER_COUNT
-          value: "100"
+        - name: STORAGE_ADAPTER
+          value: redis
+        - name: DEIS_LOGGER_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: logger-redis-creds
+              key: password
         ports:
         - containerPort: 8088
           name: http

--- a/manifests/deis-logger-rc.yaml
+++ b/manifests/deis-logger-rc.yaml
@@ -19,8 +19,6 @@ spec:
         image: quay.io/deis/logger:v2-beta
         imagePullPolicy: Always
         env:
-        - name: STORAGE_ADAPTER
-          value: redis
         - name: DEIS_LOGGER_REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/storage/adapter.go
+++ b/storage/adapter.go
@@ -2,8 +2,10 @@ package storage
 
 // Adapter is an interface for pluggable components that store log messages.
 type Adapter interface {
+	Start()
 	Write(string, string) error
 	Read(string, int) ([]string, error)
 	Destroy(string) error
 	Reopen() error
+	Stop()
 }

--- a/storage/file_adapter.go
+++ b/storage/file_adapter.go
@@ -22,6 +22,10 @@ func NewFileAdapter() (Adapter, error) {
 	return &fileAdapter{files: make(map[string]*os.File)}, nil
 }
 
+// Start the storage adapter-- in the case of this implementation, a no-op
+func (a *fileAdapter) Start() {
+}
+
 // Write adds a log message to to an app-specific log file
 func (a *fileAdapter) Write(app string, message string) error {
 	// Check first if we might actually have to add to the map of file pointers so we can avoid
@@ -93,6 +97,7 @@ func (a *fileAdapter) Destroy(app string) error {
 	return nil
 }
 
+// Reopen every file referenced by this storage adapter
 func (a *fileAdapter) Reopen() error {
 	// Ensure no other goroutine is trying to add a file pointer to the map of file pointers while
 	// we're trying to clear it out
@@ -100,6 +105,10 @@ func (a *fileAdapter) Reopen() error {
 	defer a.mutex.Unlock()
 	a.files = make(map[string]*os.File)
 	return nil
+}
+
+// Stop the storage adapter-- in the case of this implementation, a no-op
+func (a *fileAdapter) Stop() {
 }
 
 func (a *fileAdapter) getFile(app string) (*os.File, error) {

--- a/storage/redis_adapter.go
+++ b/storage/redis_adapter.go
@@ -71,7 +71,7 @@ type redisAdapter struct {
 }
 
 // NewRedisStorageAdapter returns a pointer to a new instance of a redis-based storage.Adapter.
-func NewRedisStorageAdapter(bufferSize int) (*redisAdapter, error) {
+func NewRedisStorageAdapter(bufferSize int) (Adapter, error) {
 	if bufferSize <= 0 {
 		return nil, fmt.Errorf("Invalid buffer size: %d", bufferSize)
 	}

--- a/storage/redis_adapter_test.go
+++ b/storage/redis_adapter_test.go
@@ -120,7 +120,7 @@ func TestRedisDestroy(t *testing.T) {
 	// there are 50 queued up OR a 1 second timeout has been reached.
 	time.Sleep(time.Second * 2)
 	// A redis list should exist for the app
-	exists, err := a.redisClient.Exists(app).Result()
+	exists, err := a.(*redisAdapter).redisClient.Exists(app).Result()
 	if err != nil {
 		t.Error(err)
 	}
@@ -132,7 +132,7 @@ func TestRedisDestroy(t *testing.T) {
 		t.Error(err)
 	}
 	// Now check that the redis list no longer exists
-	exists, err = a.redisClient.Exists(app).Result()
+	exists, err = a.(*redisAdapter).redisClient.Exists(app).Result()
 	if err != nil {
 		t.Error(err)
 	}

--- a/storage/redis_adapter_test.go
+++ b/storage/redis_adapter_test.go
@@ -5,6 +5,7 @@ package storage
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestRedisReadFromNonExistingApp(t *testing.T) {
@@ -42,12 +43,17 @@ func TestRedisLogs(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	a.Start()
+	defer a.Stop()
 	// And write a few logs to it, but do NOT fill it up
 	for i := 0; i < 5; i++ {
 		if err := a.Write(app, fmt.Sprintf("message %d", i)); err != nil {
 			t.Error(err)
 		}
 	}
+	// Sleep for a bit because the adapter queues logs internally and writes them to Redis only when
+	// there are 50 queued up OR a 1 second timeout has been reached.
+	time.Sleep(time.Second * 2)
 	// Read more logs than there are
 	messages, err := a.Read(app, 8)
 	if err != nil {
@@ -78,6 +84,9 @@ func TestRedisLogs(t *testing.T) {
 			t.Error(err)
 		}
 	}
+	// Sleep for a bit because the adapter queues logs internally and writes them to Redis only when
+	// there are 50 queued up OR a 1 second timeout has been reached.
+	time.Sleep(time.Second * 2)
 	// Read more logs than the buffer can hold
 	messages, err = a.Read(app, 20)
 	if err != nil {
@@ -101,10 +110,15 @@ func TestRedisDestroy(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+	a.Start()
+	defer a.Stop()
 	// Write a log to create the file
 	if err := a.Write(app, "Hello, log!"); err != nil {
 		t.Error(err)
 	}
+	// Sleep for a bit because the adapter queues logs internally and writes them to Redis only when
+	// there are 50 queued up OR a 1 second timeout has been reached.
+	time.Sleep(time.Second * 2)
 	// A redis list should exist for the app
 	exists, err := a.redisClient.Exists(app).Result()
 	if err != nil {

--- a/storage/ring_buffer_adapter.go
+++ b/storage/ring_buffer_adapter.go
@@ -63,6 +63,10 @@ func NewRingBufferAdapter(bufferSize int) (Adapter, error) {
 	return &ringBufferAdapter{bufferSize: bufferSize, ringBuffers: make(map[string]*ringBuffer)}, nil
 }
 
+// Start the storage adapter-- in the case of this implementation, a no-op
+func (a *ringBufferAdapter) Start() {
+}
+
 // Write adds a log message to to an app-specific ringBuffer
 func (a *ringBufferAdapter) Write(app string, message string) error {
 	// Check first if we might actually have to add to the map of ringBuffer pointers so we can avoid
@@ -110,7 +114,11 @@ func (a *ringBufferAdapter) Destroy(app string) error {
 	return nil
 }
 
+// Reopen the storage adapter-- in the case of this implementation, a no-op
 func (a *ringBufferAdapter) Reopen() error {
-	// No-op
 	return nil
+}
+
+// Stop the storage adapter-- in the case of this implementation, a no-op
+func (a *ringBufferAdapter) Stop() {
 }


### PR DESCRIPTION
~~This is my first pass at optimizing the logger's use of Redis. It reduces ops required by using larger pipelines capped with whatever ltrims are needed (one per app) instead of smaller pipelines that contain only one rpush and one ltrim.~~

~~This is mostly just for @arschles to review and propose improvements.~~

This PR includes the following:
- Optimize the Redis storage adapter to build and execute bigger pipelines and (in total) submit fewer operations.
- Make the Redis storage adapter pass some style checks it previously failed.
- Update the logger's manifest to include the password for Redis. This references a secret that is assumed to exist from when the `workflow-dev` chart was installed in advance of any logger hacking.
- Make the Redis storage adapter the _default_ storage adapter.