### PR TITLE
chore(redis): Make pipeline configurable

### DIFF
--- a/storage/redis_config.go
+++ b/storage/redis_config.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"time"
+
 	"github.com/kelseyhightower/envconfig"
 )
 
@@ -9,10 +11,13 @@ const (
 )
 
 type redisConfig struct {
-	RedisHost     string `envconfig:"DEIS_LOGGER_REDIS_SERVICE_HOST" default:""`
-	RedisPort     int    `envconfig:"DEIS_LOGGER_REDIS_SERVICE_PORT" default:"6379"`
-	RedisPassword string `envconfig:"DEIS_LOGGER_REDIS_PASSWORD" default:""`
-	RedisDB       int    `envconfig:"DEIS_LOGGER_REDIS_DB" default:"0"`
+	Host                   string `envconfig:"DEIS_LOGGER_REDIS_SERVICE_HOST" default:""`
+	Port                   int    `envconfig:"DEIS_LOGGER_REDIS_SERVICE_PORT" default:"6379"`
+	Password               string `envconfig:"DEIS_LOGGER_REDIS_PASSWORD" default:""`
+	DB                     int    `envconfig:"DEIS_LOGGER_REDIS_DB" default:"0"`
+	PipelineLength         int    `envconfig:"DEIS_LOGGER_REDIS_PIPELINE_LENGTH" default:"50"`
+	PipelineTimeoutSeconds int    `envconfig:"DEIS_LOGGER_REDIS_PIPELINE_TIMEOUT_SECONDS" default:"1"`
+	PipelineTimeout        time.Duration
 }
 
 func parseConfig(appName string) (*redisConfig, error) {
@@ -20,5 +25,6 @@ func parseConfig(appName string) (*redisConfig, error) {
 	if err := envconfig.Process(appName, ret); err != nil {
 		return nil, err
 	}
+	ret.PipelineTimeout = time.Duration(ret.PipelineTimeoutSeconds) * time.Second
 	return ret, nil
 }


### PR DESCRIPTION
At @jchauncey's suggestion, I am making Redis pipelines more configurable in terms of their length and in terms of how long we will queue up messages before executing a pipeline that has _not_ yet reached the configured length. (This is to avoid a large delay in messages reaching Redis when log volumes are low.)

This PR does not change the default values.