### PR TITLE
chore(Makefile): update to go-dev 0.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ REPO_PATH = github.com/deis/logger
 
 # The following variables describe the containerized development environment
 # and other build options
-DEV_ENV_IMAGE := quay.io/deis/go-dev:0.13.0
+DEV_ENV_IMAGE := quay.io/deis/go-dev:0.17.0
 DEV_ENV_WORK_DIR := /go/src/${REPO_PATH}
 DEV_ENV_OPTS := --rm -v ${CURDIR}:${DEV_ENV_WORK_DIR} -w ${DEV_ENV_WORK_DIR}
 DEV_ENV_CMD := docker run ${DEV_ENV_OPTS} ${DEV_ENV_IMAGE}

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/deis/base:0.2.0
+FROM quay.io/deis/base:0.3.1
 
 # Add logger user and group
 RUN adduser --system \


### PR DESCRIPTION
Includes the go 1.7 toolchain: faster, smaller, better. See https://tip.golang.org/doc/go1.7.

Also updates the Docker base image to deis/base:0.3.1.