### PR TITLE
feat(pprof): Add pprof endpoint

### DIFF
--- a/weblog/router.go
+++ b/weblog/router.go
@@ -1,10 +1,20 @@
 package weblog
 
 import (
+	"log"
+	"net/http"
+
+	_ "net/http/pprof"
+
 	"github.com/gorilla/mux"
 )
 
 func newRouter(rh *requestHandler) *mux.Router {
+
+	go func() {
+		log.Println(http.ListenAndServe("0.0.0.0:8099", nil))
+	}()
+
 	r := mux.NewRouter()
 	r.HandleFunc("/healthz", rh.getHealthz).Methods("GET")
 	r.HandleFunc("/healthz/", rh.getHealthz).Methods("GET")


### PR DESCRIPTION
We will now include a pprof endpoint located at http://0.0.0.0:8099/debug/pprof. This allows user to exec into the running pod and look at debug information like number of executing goroutines and memory profile.

Test Steps:

* Clone PR
* `make build push upgrade` into your k8s cluster
* `kubectl exec` into your running logger container. 
* `curl localhost:8099/debug/pprof/heap`

You can find more information here - https://golang.org/pkg/net/http/pprof/