### PR TITLE
chore(glide): update envconfig

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: f3b2325d3480fc63a4d4e32f74387dbf6e59607ae0c03d3685f98502f4817f11
-updated: 2016-10-26T14:47:28.134518584-04:00
+updated: 2016-12-06T17:35:19.509392042Z
 imports:
 - name: github.com/gorilla/context
   version: aed02d124ae4a0e94fea4541c8effd05bf0c8296
 - name: github.com/gorilla/mux
   version: 9fa818a44c2bf1396a17f9d5a3c0f6dd39d2ff8e
 - name: github.com/kelseyhightower/envconfig
-  version: 91921eb4cf999321cdbeebdba5a03555800d493b
+  version: 5c008110b20b657eb7e005b83d0a5f6aa6bb5f4b
 - name: github.com/mreiferson/go-snappystream
   version: 028eae7ab5c4c9e2d1cb4c4ca1e53259bbe7e504
   subpackages:


### PR DESCRIPTION
envconfig has come out with a few major fixes, one fix being a proper error message that displays the reason for the parsing error found in #127. See https://github.com/kelseyhightower/envconfig/commit/13674b2d056fb658a00ba3f36e78043ced07c924

See https://github.com/kelseyhightower/envconfig/compare/91921eb4cf999321cdbeebdba5a03555800d493b...5c008110b20b657eb7e005b83d0a5f6aa6bb5f4b