### PR TITLE
fix(log): fix panic error when building app log message

### DIFF
--- a/log/message_handler.go
+++ b/log/message_handler.go
@@ -53,11 +53,17 @@ func buildControllerLogMessage(message *Message) string {
 }
 
 func buildApplicationLogMessage(message *Message) string {
-	return fmt.Sprintf("%s %s[%s.%s.%s]: %s",
+	p := podRegex.FindStringSubmatch(message.Kubernetes.PodName)
+	tag := fmt.Sprintf(
+		"%s.%s",
+		message.Kubernetes.Labels["type"],
+		message.Kubernetes.Labels["version"])
+	if len(p) > 0 {
+		tag = fmt.Sprintf("%s.%s", tag, p[len(p)-1])
+	}
+	return fmt.Sprintf("%s %s[%s]: %s",
 		message.Time.Format(timeFormat),
 		message.Kubernetes.Labels["app"],
-		message.Kubernetes.Labels["type"],
-		message.Kubernetes.Labels["version"],
-		podRegex.FindStringSubmatch(message.Kubernetes.PodName)[4],
+		tag,
 		message.Log)
 }

--- a/log/message_handler_test.go
+++ b/log/message_handler_test.go
@@ -18,6 +18,9 @@ var (
 	validAppMessage = `{"log": "test message", "stream": "stderr", "time": "2016-10-18T20:29:38+00:00", "docker": {"container_id": "containerId"}, "kubernetes": {"namespace_name": "foo", "pod_id": "podId", "pod_name": "foo-web-845861952-nzf60", "container_name": "foo-web", "labels": {"app": "foo",
 "heritage": "deis", "type": "web", "version": "v2"}, "host": "host"}}`
 
+	badPodNameMessage = `{"log": "test message", "stream": "stderr", "time": "2016-10-18T20:29:38+00:00", "docker": {"container_id": "containerId"}, "kubernetes": {"namespace_name": "foo", "pod_id": "podId", "pod_name": "foo-web-845861952", "container_name": "foo-web", "labels": {"app": "foo",
+"heritage": "deis", "type": "web", "version": "v2"}, "host": "host"}}`
+
 	badjson = `{"log":}`
 )
 
@@ -60,6 +63,16 @@ func TestBuildApplicationLogMessageFromValidMessage(t *testing.T) {
 	expected := buildApplicationLogMessage(message)
 	assert.Equal(t, expected,
 		"2016-10-18T20:29:38+00:00 foo[web.v2.nzf60]: test message",
+		"failed to build application log")
+}
+
+func TestBuildApplicationLogMessageFromInvalidMessage(t *testing.T) {
+	message := new(Message)
+	err := json.Unmarshal([]byte(badPodNameMessage), message)
+	assert.NoError(t, err, "error occured parsing log message")
+	expected := buildApplicationLogMessage(message)
+	assert.Equal(t, expected,
+		"2016-10-18T20:29:38+00:00 foo[web.v2]: test message",
 		"failed to build application log")
 }
 


### PR DESCRIPTION
closes #136 by catching when the pod name fails the pod regex.